### PR TITLE
modified stack name to match

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,9 +9,9 @@
     "preview": "vite preview",
     "deploy": "npm run sync && npm run invalidate-cache && npm run print-website-url",
     "publish": "npm run build && npm run deploy",
-    "sync": "aws s3 sync dist/ s3://$(aws cloudformation describe-stacks --output text --query 'Stacks[?contains(StackName, `assettracker`)][].Outputs[?contains(OutputKey, `StaticAssetsBucketName`)].OutputValue')/ --delete",
-    "print-website-url": "echo \"Website published at $(aws cloudformation describe-stacks --output text --query 'Stacks[?contains(StackName, `assettracker`)][].Outputs[?contains(OutputKey, `cloudfrontDomainName`)].OutputValue')\n\"",
-    "invalidate-cache": "aws cloudfront create-invalidation --output yaml --distribution-id $(aws cloudformation describe-stacks --output text --query 'Stacks[?contains(StackName, `assettracker`)][].Outputs[?contains(OutputKey, `cloudfrontDistributionId`)].OutputValue') --paths '/index.html' --no-cli-pager"
+    "sync": "aws s3 sync dist/ s3://$(aws cloudformation describe-stacks --output text --query 'Stacks[?contains(StackName, `AssetTracker`)][].Outputs[?contains(OutputKey, `StaticAssetsBucketName`)].OutputValue')/ --delete",
+    "print-website-url": "echo \"Website published at $(aws cloudformation describe-stacks --output text --query 'Stacks[?contains(StackName, `AssetTracker`)][].Outputs[?contains(OutputKey, `cloudfrontDomainName`)].OutputValue')\n\"",
+    "invalidate-cache": "aws cloudfront create-invalidation --output yaml --distribution-id $(aws cloudformation describe-stacks --output text --query 'Stacks[?contains(StackName, `AssetTracker`)][].Outputs[?contains(OutputKey, `cloudfrontDistributionId`)].OutputValue') --paths '/index.html' --no-cli-pager"
   },
   "dependencies": {
     "@aws-amplify/ui-react": "^5.0.4",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Modifying the stack name from *assettracker* to *AssetTracker* to match with the stack name used in the CDK. AWS CLI query seems case sensitive, hence below query returns nothing and as a result *npm run deploy* fails.

```shell
$(aws cloudformation describe-stacks --output text --query 'Stacks[?contains(StackName, `assettracker`)][].Outputs[?contains(OutputKey, `cloudfrontDistributionId`)].OutputValue')
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
