### PR TITLE
Updated frontend cache invalidator to use text output.

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "publish": "npm run build && npm run deploy",
     "sync": "aws s3 sync dist/ s3://$(aws cloudformation describe-stacks --output text --query 'Stacks[?contains(StackName, `AssetTracker`)][].Outputs[?contains(OutputKey, `StaticAssetsBucketName`)].OutputValue')/ --delete",
     "print-website-url": "echo \"Website published at $(aws cloudformation describe-stacks --output text --query 'Stacks[?contains(StackName, `AssetTracker`)][].Outputs[?contains(OutputKey, `cloudfrontDomainName`)].OutputValue')\n\"",
-    "invalidate-cache": "aws cloudfront create-invalidation --output yaml --distribution-id $(aws cloudformation describe-stacks --output text --query 'Stacks[?contains(StackName, `AssetTracker`)][].Outputs[?contains(OutputKey, `cloudfrontDistributionId`)].OutputValue') --paths '/index.html' --no-cli-pager"
+    "invalidate-cache": "aws cloudfront create-invalidation --output text --distribution-id $(aws cloudformation describe-stacks --output text --query 'Stacks[?contains(StackName, `AssetTracker`)][].Outputs[?contains(OutputKey, `cloudfrontDistributionId`)].OutputValue') --paths '/index.html'"
   },
   "dependencies": {
     "@aws-amplify/ui-react": "^5.0.4",


### PR DESCRIPTION
Due to the aws cli no longer supporting yaml as an output format, the aws cli command for invalidating the cloudfront cache now sets output type to 'text'. 
